### PR TITLE
Update README to ASP.NET Core 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Note that the repo doesn't include solution and project files, but should be cop
 The assumption is that you started with an empty web application, added identityserver and configured the resources, clients and users. 
 
 ### Adding MVC
-The quickstart UI uses MVC. Before you can add the UI you need to add the following nuget packages:
+The quickstart UI uses MVC. Before you can add the UI you need to add the following nuget packages (these packages are not required if you're targeting ASP.NET Core 2.0 and the package `Microsoft.AspNetCore.All` is installed):
 
 ```
 Microsoft.AspNetCore.Mvc


### PR DESCRIPTION
- The package `Microsoft.AspNetCore.All` depends on
`Microsoft.AspNetCore.Mvc` and `Microsoft.AspNetCore.StaticFiles`. There
is no need to add them.

Fix #25