### PR TITLE
Update get.ps1

### DIFF
--- a/get.ps1
+++ b/get.ps1
@@ -1,4 +1,5 @@
 $source = "https://github.com/IdentityServer/IdentityServer4.Quickstart.UI/archive/release.zip"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest $source -OutFile ui.zip
 
 Expand-Archive ui.zip


### PR DESCRIPTION
Documentation Tutorial has a broken PowerShell command (adding the ui)
The script currently does not take care about TLS changes.
This will switch to TLS 1.2 before making the request