### PR TITLE
Add support for SAML2 external logout

### DIFF
--- a/Quickstart/Account/ExternalController.cs
+++ b/Quickstart/Account/ExternalController.cs
@@ -236,6 +236,8 @@ namespace Host.Quickstart.Account
 
         private void ProcessLoginCallbackForSaml2p(AuthenticateResult externalResult, List<Claim> localClaims, AuthenticationProperties localSignInProps)
         {
+            // Carry over claims neeed to do SAML2 single logout.
+            localClaims.AddRange(externalResult.Principal.Claims.Where(c => c.Type.StartsWith("http://Sustainsys.se/Saml2")));
         }
     }
 }


### PR DESCRIPTION
The Sustainsys.Saml2 creates two special claims (Session index and LogoutNameIdentifier) that are needed to do single logout with an upstream Idp. Carry them over to the generated identity.