### PR TITLE
fixed ExternalController namespace

### DIFF
--- a/Quickstart/Account/ExternalController.cs
+++ b/Quickstart/Account/ExternalController.cs
@@ -15,7 +15,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Host.Quickstart.Account
+namespace IdentityServer4.Quickstart.UI
 {
     [SecurityHeaders]
     [AllowAnonymous]


### PR DESCRIPTION
Changed ExternalController namespace from Host.Quickstart.Account to IdentityServer4.Quickstart.UI to make it consistent with every other file.