### PR TITLE
Listing IdentityServer4 namespace at the top of class in-favour of Id…

### DIFF
--- a/Quickstart/Account/AccountController.cs
+++ b/Quickstart/Account/AccountController.cs
@@ -3,6 +3,7 @@
 
 
 using IdentityModel;
+using IdentityServer4;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;

--- a/Quickstart/Account/ExternalController.cs
+++ b/Quickstart/Account/ExternalController.cs
@@ -1,4 +1,5 @@
 using IdentityModel;
+using IdentityServer4;
 using IdentityServer4.Events;
 using IdentityServer4.Services;
 using IdentityServer4.Stores;


### PR DESCRIPTION
Listing `IdentityServer4` namespace at the top of `AccountController.cs` and `ExternalController.cs` in-favour of `IdentityServerUser` usage.
With this fix `is4ui` template would compile, no matter what namespace/project name is chosen by user.

**What issue does this PR address?**
https://github.com/IdentityServer/IdentityServer4/issues/4385

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/IdentityServer/IdentityServer4/blob/master/.github/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
