### PR TITLE
Small route value renaming fix

### DIFF
--- a/Quickstart/Account/AccountController.cs
+++ b/Quickstart/Account/AccountController.cs
@@ -64,7 +64,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (vm.IsExternalLoginOnly)
             {
                 // we only have one option for logging in and it's an external provider
-                return RedirectToAction("Challenge", "External", new { provider = vm.ExternalLoginScheme, returnUrl });
+                return RedirectToAction("Challenge", "External", new { scheme = vm.ExternalLoginScheme, returnUrl });
             }
 
             return View(vm);


### PR DESCRIPTION
**What issue does this PR address?**
The External/Challenge action expects a `scheme` route value instead of a `provider` value. This way the auto redirect works again if only one external provider is registered and local authentication is disabled.

**Does this PR introduce a breaking change?**
No